### PR TITLE
Refactor find item logic into hook

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,0 +1,29 @@
+import { useRef } from "react";
+
+// Only works with domElements. Could this be further generalized?
+// This hook returns a function that accepts a typed character code
+// and domElements with text content. It will return the node that
+// matches the typed character(s) within the delay. The function uses
+// refs to hold values between renders. Maybe this could be done using
+// plain JS objects and closures. I went with React refs since they
+// persist between renders.
+export const useFindTypedItem = (delay = 500) => {
+  const cacheTypedChars = useRef("");
+  const cachedTimeoutId = useRef(null);
+  return (charCode, domElements) => {
+    cacheTypedChars.current += String.fromCharCode(charCode).toLowerCase();
+    if (cachedTimeoutId.current) {
+      clearTimeout(cachedTimeoutId.current);
+    }
+    cachedTimeoutId.current = setTimeout(
+      () => (cacheTypedChars.current = ""),
+      delay
+    );
+    if (cacheTypedChars.current) {
+      const foundItem = domElements.filter(node =>
+        node.textContent.toLowerCase().startsWith(cacheTypedChars.current)
+      )[0];
+      return foundItem;
+    }
+  };
+};


### PR DESCRIPTION
A bit of code I came across that might not need to be at the component level and can be pulled out into a Hook. Cleans up file and allows logic to be reused elsewhere.