### PR TITLE
useReducer: Refactor Shipt Combobox  

### DIFF
--- a/stories/ShiptComboBox/actionTypes.js
+++ b/stories/ShiptComboBox/actionTypes.js
@@ -1,0 +1,17 @@
+export const CLEAR_OPTION = "clear option";
+
+export const COLLAPSE_LIST = "collapse list";
+
+export const FOCUS_PREVIOUS_OPTION = "focus previous option";
+
+export const FOCUS_NEXT_OPTION = "focus next option";
+
+export const HIGHLIGHT = "highlight";
+
+export const SELECT_LIST_ITEM = "select list item";
+
+export const SET_ACTIVE_ID = "set active id";
+
+export const UPDATE_QUERY = "update query";
+
+export const UPDATE_SUGGESTIONS = "update suggestions";

--- a/stories/ShiptComboBox/reducer.js
+++ b/stories/ShiptComboBox/reducer.js
@@ -1,0 +1,70 @@
+import * as types from "./actionTypes.js";
+
+export const initialState = {
+  query: "",
+  activeId: "",
+  expanded: false,
+  suggestions: [],
+  activeIndex: -1,
+  highlightIndex: -1
+};
+
+const comboBoxReducer = (state, action) => {
+  const { activeIndex, suggestions } = state;
+  let nextIdx;
+  switch (action.type) {
+    case types.COLLAPSE_LIST:
+      return { ...state, expanded: false };
+    case types.FOCUS_PREVIOUS_OPTION:
+      nextIdx = activeIndex > 0 ? activeIndex - 1 : suggestions.length - 1;
+      return {
+        ...state,
+        activeIndex: nextIdx,
+        highlightIndex: nextIdx
+      };
+    case types.FOCUS_NEXT_OPTION:
+      nextIdx = activeIndex === suggestions.length - 1 ? 0 : activeIndex + 1;
+      return {
+        ...state,
+        activeIndex: nextIdx,
+        highlightIndex: nextIdx
+      };
+    case types.UPDATE_SUGGESTIONS:
+      return {
+        ...state,
+        expanded: true,
+        activeIndex: -1,
+        highlightIndex: -1,
+        suggestions: action.suggestions
+      };
+    case types.HIGHLIGHT:
+      return {
+        ...state,
+        activeIndex: action.highlightIndex,
+        highlightIndex: action.highlightIndex
+      };
+    case types.UPDATE_QUERY:
+      return {
+        ...state,
+        query: action.query
+      };
+    case types.CLEAR_OPTION:
+      return {
+        ...state,
+        activeIndex: -1,
+        highlightIndex: -1
+      };
+    case types.SELECT_LIST_ITEM:
+      return {
+        ...state,
+        expanded: false,
+        query: suggestions[activeIndex] || ""
+      };
+    case types.SET_ACTIVE_ID:
+      return { ...state, activeId: action.activeId };
+    default:
+      throw new Error("This action type is not supported");
+  }
+};
+
+export default comboBoxReducer;


### PR DESCRIPTION
## Problem

`useState` is used six times to manage six separate pieces of state. These states are closely related so `useReducer` may be more suitable than multiple `useState`s. Also, by using `useReducer` the component code is a bit more declarative.

## Solution

Replace `useState` with `useReducer`. Both of these hooks are used to persist state between React component renders and provides an API to trigger a render. `useState` provides a set state function and `useReducer` provides a dispatch function to update state.

The `useReducer` hook is preferred in this situation because multiple state values are related to each other for particular actions. One example is collapsing the listbox of a combobox. This action involves updating multiple state values:

```jsx
setExpanded(false);
setActiveId(undefined);
setActiveIndex(-1);
setHighlightIndex(-1);
setSuggestions([]);
```

This is a good situation to abstract this logic away into a reducer function. In our component code, rather than calling each set state function, we could encapsulate the code into a single reducer case and the component code simply has to dispatch a plan action object:

```jsx
// reducer
const reducer = (state, action) => {
  if (action.type === 'collapse') {
    return {
      expanded: false,
      activeId: undefined,
      activeIndex: -1,
      highlightedIndex: -1,
      suggestions: []
    }
  }
}

// component code
<div onBlur={() => dispatch({ type: 'collapse' })} />
```

Notice that this allows our component code to be more declarative because we simply have to dispatch actions that describe the next state change.

Here's another good use case for moving from `useState` to `useReducer`: whenever the user presses on the down arrow key, we would like to move DOM focus to the next list item in the listbox. Inside our component code, we had a switch statement with some logic to handle this:

```jsx
// component code
switch (e.keyCide) {
  case KEY_CODE.down:
  if (activeIndex === suggestions.length - 1) {
    setActiveIndex(0);
  } else {
    setActiveIndex(activeIndex + 1);
  }
}
```

By moving to `useReducer` we can encapsulate the `if` condition logic and set states into a reducer function:

```jsx
const reducer = (state, action) => {
  if (action.type === 'focus next option') {
    nextIdx = activeIndex === suggestions.length - 1 ? 0 : activeIndex + 1;
    return {
      ...state,
      activeIndex: nextIdx,
      highlightIndex: nextIdx
    };
  }
}
```

Then our component becomes more declarative:

```jsx
// before, notice imperative nature of this code and the logic/
switch (e.keyCide) {
  case KEY_CODE.down:
  if (activeIndex === suggestions.length - 1) {
    setActiveIndex(0);
  } else {
    setActiveIndex(activeIndex + 1);
  }
}

// after, notice that this is a declarative action that describes the next state
switch (e.keyCode) {
  case KEY_CODE.down:
    dispatch({ type: 'collapse' })
}
```

## Future

In the future, I may try to abstract away the reducer logic into a custom hook to be reused in similar combobox components.